### PR TITLE
Fix fatal error on events update

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/services/UpdateEventsService.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/UpdateEventsService.php
@@ -4,33 +4,38 @@ namespace meumobi\sitebuilder\services;
 
 use app\models\extensions\EventFeed;
 use app\models\items\Events;
+use Exception;
 use lithium\data\Connections;
+use meumobi\sitebuilder\Logger;
 use Model;
+use SimpleXMLElement;
 
 class UpdateEventsService extends Service {
 	public function call() {
-		$this->logger()->info('updating events', [
-				'priority' => $this->options['priority']
-				]);
+		Logger::info('events', 'updating events from feeds', [
+			'priority' => $this->options['priority']
+		]);
 		$stats = ['start_time' => microtime(true)];
-
 		$db = Connections::get('default')->connection;
-		$feeds = $db->extensions->find ( [
+		$extensions = $db->extensions->find ( [
 				'extension' => 'event-feed',
 				'enabled' => 1,
 				'priority' => $this->priorityCriteria ()
-		] );
-		foreach ($feeds as $feed) {
+			]);
+
+		foreach ($extensions as $extension) {
 			try {
-				$this->logger()->debug('downloading feed', ['url' => $feed['url']]);
-				$events = new \SimpleXMLElement(file_get_contents($feed['url']));
-				$this->logger()->debug('finished downloading feed');
-				$category = Model::load('Categories')->firstById($feed['category_id']);
+				Logger::info('events', 'downloading feed', ['url' => $extension['url']]);
+				$events = new SimpleXMLElement(file_get_contents($extension['url']));
+				Logger::info('events', 'finished downloading feed');
+				$category = Model::load('Categories')->firstById($extension['category_id']);
+
 				foreach ($events as $event) {
 					$hasItem = Events::find('count', array('conditions' => array(
 						'parent_id' => $category->id,
 						'guid' => (string)$event['id']
 					)));
+
 					if (!$hasItem) {
 						$data = array (
 								'site_id' => $category->site_id,
@@ -43,27 +48,32 @@ class UpdateEventsService extends Service {
 								'end_date' => (string)$event->end_date,
 								'type' => 'events',
 						);
-						//print_r($data); continue;
+
 						Events::create($data)->save();
-						$this->logger()->debug('saved event',
-								['title' => $data['title']]);
+						Logger::info('events', 'saved event', ['title' => $data['title']]);
 					}
 				}
+
 				$db->extensions->update([
 					'extension' => 'event-feed',
-					'_id' => $feed['_id']
+					'_id' => $extension['_id']
 				], ['$unset' => ['priority' => '']]);
-				$this->logger()->debug('finished feed', ['url' => $feed['url']]);
-			} catch ( Exception $e ) {
-				$this->logger->error('events update error', [
-						'exception' => get_class($e),
-						'message' => $e->getMessage(),
-						'trace' => $e->getTraceAsString()]);
+
+				Logger::info('events', 'finished feed', ['url' => $extension['url']]);
+			} catch (Exception $e) {
+				EventFeed::update(['enabled' => false], ['_id' => $extension['_id']]);
+
+				Logger::info('events', 'feed update error, extension has disabled', [
+					'error' => $e->getMessage(),
+					'extension id' => $extension['_id'],
+					'category id' => $extension['category_id'],
+				]);
 			}
-			$stats['end_time'] = microtime(true);
-			$stats['elapsed_time'] = array_unset($stats, 'end_time') -
-			array_unset($stats, 'start_time');
-			$this->logger()->info('finished updating events', $stats);
 		}
+
+		$stats['end_time'] = microtime(true);
+		$stats['elapsed_time'] = array_unset($stats, 'end_time') -
+		array_unset($stats, 'start_time');
+		Logger::info('events', 'finished updating events from feeds', $stats);
 	}
 }


### PR DESCRIPTION
Fixes fatal errors due to uncaught exceptions and disables the extension if some error occurs during the update, like invalid feeds or categories.

Closes #118