### PR TITLE
Re-add token replacing for segments

### DIFF
--- a/sitebuilder/app/controllers/app_controller.php
+++ b/sitebuilder/app/controllers/app_controller.php
@@ -119,6 +119,7 @@ function __($key) {
 
 function s($key) {
 	$arguments = func_get_args();
+	$arguments[0] = YamlDictionary::translate($key);
 	return call_user_func_array('__', $arguments);
 }
 


### PR DESCRIPTION
This was removed in 48291f3f98fb73d77163d5579ef892016807201d for unknown
reasons. As a result, calling s() to replace a token with a personalized
string for a segment stopped working, because it was only doing the
translation. Adding this line back makes it work again.