### PR TITLE
Set the correct guid in the Rss export

### DIFF
--- a/sitebuilder/app/controllers/api/ItemsController.php
+++ b/sitebuilder/app/controllers/api/ItemsController.php
@@ -2,14 +2,16 @@
 
 namespace app\controllers\api;
 
-use app\models\Items;
-use app\models\RecordNotFoundException;
+use Exception;
 use I18n;
 use Inflector;
-use lithium\core\Object;
-use meumobi\sitebuilder\services\ItemCreation;
 use Model;
 use View;
+use app\models\Items;
+use app\models\RecordNotFoundException;
+use lithium\core\Object;
+use meumobi\sitebuilder\presenters\api\RssItemPresenter;
+use meumobi\sitebuilder\services\ItemCreation;
 
 class ItemsController extends ApiController {
 	const PAGE_LIMIT = 20;
@@ -59,8 +61,10 @@ class ItemsController extends ApiController {
 		$url = "/api/{$this->site()->domain()}/categories/{$category->id}/items";
 		$url_params = ['category' => $category_id];
 
+		$items = $this->getItems($params, $url, $url_params);
+
 		$data = [
-			'items' => $this->getItems($params, $url, $url_params),
+			'items' => RssItemPresenter::presentSet($items),
 			'site' => $this->site()
 		];
 
@@ -323,8 +327,8 @@ class ItemsController extends ApiController {
 		}
 
 		foreach ($need as $field) {
-			if (!array_key_exists($field,$data)) {
-				throw new \Exception('need more params: '. $field);
+			if (!array_key_exists($field, $data)) {
+				throw new Exception('need more params: '. $field);
 			}
 		}
 

--- a/sitebuilder/app/views/items/feed.rss.php
+++ b/sitebuilder/app/views/items/feed.rss.php
@@ -1,16 +1,16 @@
 <?xml version="1.0"?>
 <rss version="2.0">
    <channel>
-      <title><?php echo Sanitize::html($site->title) ?></title>
-      <link><?php echo $site->link() ?></link>
-      <description><?php echo Sanitize::html($site->title) ?></description>
+      <title><?= e($site->title) ?></title>
+      <link><?= $site->link() ?></link>
+      <description><?= e($site->title) ?></description>
       <?php foreach($items as $item): ?>
         <item>
-            <title><?php echo Sanitize::html($item['title']) ?></title>
-            <link><?php echo $item['link'] ?: 'http://meumobi.com' ?></link>
-            <description><![CDATA[<?php echo $item['description'] ?>]]></description>
-            <pubDate><?php echo date(DATE_RSS, $item['published']) ?></pubDate>
-            <guid><?php echo $item['guid'] ?: 'http://meumobi.com/' ?></guid>
+            <title><?= e($item['title']) ?></title>
+            <link><?= $item['link'] ?></link>
+            <description><![CDATA[<?= $item['description'] ?>]]></description>
+            <pubDate><?= $item['published'] ?></pubDate>
+            <guid><?= $item['guid'] ?></guid>
         </item>
       <?php endforeach ?>
    </channel>

--- a/sitebuilder/lib/meumobi/sitebuilder/presenters/api/RssItemPresenter.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/presenters/api/RssItemPresenter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace meumobi\sitebuilder\presenters\api;
+
+use Mapper;
+use Model;
+
+class RssItemPresenter
+{
+	public static function present($item)
+	{
+		$site = Model::load('Sites')->firstById($item['site_id']);
+		$link = "http://{$site->domain()}/items/{$item['_id']}";
+
+		return [
+			'title' => $item['title'],
+			'description' => $item['description'],
+			'published' => date(DATE_RSS, $item['published']),
+			'link' => $item['link'] ?: $link,
+			'guid' => $item['guid'] ?: $link,
+		];
+	}
+
+	public static function presentSet($set)
+	{
+		return array_map(array(__CLASS__, 'present'), $set);
+	}
+}


### PR DESCRIPTION
The Rss export was invalid because the same value(meumobi.com) is used for guid and link of each item.
To turn the rss valid, the item url is used if the item don't have the link or guid set.

closes #21