### PR TITLE
Use consistent log key names for push notification logs 

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/workers/PushNotificationWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/PushNotificationWorker.php
@@ -2,13 +2,14 @@
 
 namespace meumobi\sitebuilder\workers;
 
-use app\models\Items;
-use meumobi\sitebuilder\repositories\RecordNotFoundException;//TODO move exceptions for a more generic namespace
-use pushwoosh\Push;
-use meumobi\sitebuilder\repositories\VisitorsRepository;
-use meumobi\sitebuilder\entities\Visitor;
-
 require_once 'lib/pushwoosh/Push.php';
+
+use app\models\Items;
+use meumobi\sitebuilder\Logger;
+use meumobi\sitebuilder\entities\Visitor;
+use meumobi\sitebuilder\repositories\RecordNotFoundException;//TODO move exceptions for a more generic namespace
+use meumobi\sitebuilder\repositories\VisitorsRepository;
+use pushwoosh\Push;
 
 class PushNotificationWorker extends Worker
 {
@@ -17,28 +18,28 @@ class PushNotificationWorker extends Worker
 		$appId = $this->getSite()->pushwoosh_app_id;
 		$category = $this->getItem()->parent();
 		$logData = [
-			'item id' => (string)$this->getItem()->_id,
-			'category id' => $category->id,
-			'site id' => $this->getItem()->site_id,
+			'item_id' => (string)$this->getItem()->_id,
+			'category_id' => $category->id,
+			'site_id' => $this->getItem()->site_id,
 		];
 
 		if (!$appId) {
-			$this->logger()->error("Push notification error: no push app configured for site", $logData);
+			Logger::info('push_notification', 'no push app configured for site', $logData);
 			return true; //has no app configured
 		}
 		if (!$category->notification) {
-			$this->logger()->error("Push notification error: push disabled on category", $logData);
+			Logger::info('push_notification', 'push disabled on category', $logData);
 			return true;
 		}
 		$content = $this->getItem()->title;
 		$devices = $this->getDevicesTokens();
-		$this->logger()->info('Sending push notification', $logData + [
+		Logger::info('push_notification', 'sending push notification', $logData + [
 			'content' => $content,
-			'devices' => $devices,
+			'number_of_devices' => count($devices),
 		]);
 		$response = Push::notify($appId, $content, $devices);
-		$this->logger()->info('Push notification sent successfully', $logData + [
-			'push response' => $response,
+		Logger::info('push_notification', 'push notification sent successfully', $logData + [
+			'push_response' => $response,
 		]);
 	}
 

--- a/sitebuilder/lib/pushwoosh/Push.php
+++ b/sitebuilder/lib/pushwoosh/Push.php
@@ -1,10 +1,11 @@
 <?php
 namespace pushwoosh;
 
+Use Exception;
 use Gomoob\Pushwoosh\Client\Pushwoosh;
+use Gomoob\Pushwoosh\Model\Notification\IOS;
 use Gomoob\Pushwoosh\Model\Notification\Notification;
 use Gomoob\Pushwoosh\Model\Request\CreateMessageRequest;
-use Gomoob\Pushwoosh\Model\Notification\IOS;
 
 class Push
 {
@@ -17,14 +18,11 @@ class Push
 		$response = static::getClient($appId)->createMessage($request);
 		if ($response->isOk()) {
 			return [
-				'status code' => $response->getStatusCode(),
-				'status message' => $response->getStatusMessage()
+				'status_code' => $response->getStatusCode(),
+				'status_message' => $response->getStatusMessage()
 			];
 		} else {
-			//TODO use a specific Exception
-			throw new \Exception("Error sending push notification,
-			status code : {$response->getStatusCode()},
-			status message: {$response->getStatusMessage()}");
+			throw new Exception("Error sending push notification, status_code: {$response->getStatusCode()}, status_message: {$response->getStatusMessage()}");
 		}
 	}
 

--- a/sitebuilder/lib/pushwoosh/Push.php
+++ b/sitebuilder/lib/pushwoosh/Push.php
@@ -1,6 +1,7 @@
 <?php
 namespace pushwoosh;
 
+Use Config;
 Use Exception;
 use Gomoob\Pushwoosh\Client\Pushwoosh;
 use Gomoob\Pushwoosh\Model\Notification\IOS;
@@ -40,6 +41,6 @@ class Push
 		if (static::$client) return static::$client;
 		return static::$client = Pushwoosh::create()
 		->setApplication($app)
-		->setAuth(\Config::read('PushWoosh.authToken'));
+		->setAuth(Config::read('PushWoosh.authToken'));
 	}
 }


### PR DESCRIPTION
Replace inconsistent log key names by using underscores instead of spaces, replace the list of devices on the log for the total number of devices and update the PushNotificationWorker to use the static Logger class methods instead of an log instance.

Closes, #154

Obs. 
The log of the list of devices will be added by issue #155
The commit messages are simple, will be updated