### PR TITLE
Fix is_published filtering of GET items/latest request

### DIFF
--- a/sitebuilder/app/controllers/api/ItemsController.php
+++ b/sitebuilder/app/controllers/api/ItemsController.php
@@ -179,11 +179,13 @@ class ItemsController extends ApiController {
 		$parent_id = $this->request->get('params:parent_id');
 
 		$params = [
-			'conditions' => ['site_id' => $this->site()->id],
+			'conditions' => [
+				'site_id' => $this->site()->id,
+				'is_published' => true,
+			],
 			'order' => ['published' => 'DESC'],
 			'limit' => $this->param('limit', self::PAGE_LIMIT),
 			'page' => $this->param('page', 1),
-			'is_published' => true,
 		];
 
 		if ($parent_id) {


### PR DESCRIPTION
Remove invalid and use the correct conditional parameter to return
only the published items in the GET items/latest request.

closes #152