### PR TITLE
Prevent remove items when the extension is disabled

### DIFF
--- a/sitebuilder/app/models/Extensions.php
+++ b/sitebuilder/app/models/Extensions.php
@@ -138,7 +138,6 @@ class Extensions extends Modules
 	public static function disable($extension)
 	{
 		$category = static::category($extension);
-		$category->removeItems();
 		$category->populate = 'manual';
 		$category->save();
 	}


### PR DESCRIPTION
Update Extension disable method to not remove items after disable an extension.
closes #82