### PR TITLE
Prevent send push notification if no device available

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/workers/PushNotificationWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/PushNotificationWorker.php
@@ -37,6 +37,11 @@ class PushNotificationWorker extends Worker
 			return;
 		}
 
+		if (!$devices) {
+			Logger::info('push_notification', 'no devices available', $logData);
+			return;
+		}
+
 		Logger::info('push_notification', 'sending push notification', $logData + [
 			'content' => $content,
 			'number_of_devices' => count($devices),


### PR DESCRIPTION
If a site not have any visitor that already logged in, the push
notification is sent to all visitors because the devices filter in
the request sent to pushwoosh is not set.

To prevent this an push notification must be sent only if the devices
tokens are specified in the Api request.

Closes #151