### PR TITLE
Validate visitor before import and make import_visitors options consistent

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
@@ -54,6 +54,21 @@ class VisitorsRepository extends Repository
 		}
 	}
 
+	public function findByEmailAndSite($email, $siteId)
+	{
+		$result = $this->collection()->findOne([
+			'email' => $email,
+			'site_id' => (int) $siteId
+		]);
+
+		if ($result) {
+			return $this->hydrate($result);
+		} else {
+			throw new RecordNotFoundException("The visitor with email: '$email' and siteId: '$siteId' was not found");
+		}
+	}
+
+
 	public function findForAuthentication($siteId, $email, $password)
 	{
 		$conditions = [

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
@@ -63,8 +63,6 @@ class VisitorsRepository extends Repository
 
 		if ($result) {
 			return $this->hydrate($result);
-		} else {
-			throw new RecordNotFoundException("The visitor with email: '$email' and siteId: '$siteId' was not found");
 		}
 	}
 

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
@@ -57,8 +57,8 @@ class VisitorsRepository extends Repository
 	public function findByEmailAndSite($email, $siteId)
 	{
 		$result = $this->collection()->findOne([
-			'email' => $email,
-			'site_id' => (int) $siteId
+			'email' => trim($email),
+			'site_id' => (int) $siteId,
 		]);
 
 		if ($result) {

--- a/sitebuilder/lib/meumobi/sitebuilder/services/ImportCsvService.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/ImportCsvService.php
@@ -5,7 +5,7 @@ namespace meumobi\sitebuilder\services;
 use lithium\data\Connections;
 use app\models\Jobs;
 
-abstract class ImportCsvService extends Service {
+class ImportCsvService extends Service {
 	const INCLUSIVE = 0;
 	const EXCLUSIVE = 1;
 
@@ -14,8 +14,6 @@ abstract class ImportCsvService extends Service {
 	protected $filePath;
 	protected $lastJob;
 	protected $method;
-
-	abstract public function import();
 
 	protected function getNextItem()
 	{

--- a/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
@@ -98,9 +98,11 @@ class ImportVisitorsCsvService extends ImportCsvService
 	{
 		$this->logger()->info("updating visitor with email: {$visitor->email()}");
 
-		if ($resend) {
+		if ($resend && !$visitor->lastLogin()) {
 			$password = $passwordGenerationService->generate($visitor, $this->passwordStrategy, $this->getSite());
 			$this->sendVisitorEmail(['email' => $visitor->email(), 'password' => $password]);
+		} else if ($visitor->lastLogin()) {
+			$this->logger()->info('invite not sent because visitor already logged in', ['email' => $visitor->email()]);
 		}
 
 		$this->repository()->update($visitor);

--- a/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
@@ -38,8 +38,10 @@ class ImportVisitorsCsvService extends ImportCsvService
 				$this->repository()->create($visitor);
 				$this->sendVisitorEmail(['email' => $visitor->email(), 'password' => $password]);
 			}
+
 			$imported++;
 		}
+
 		fclose($this->getFile());
 		$this->logger()->info("total of imported visitors: $imported");
 		return $imported;

--- a/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
@@ -78,14 +78,12 @@ class ImportVisitorsCsvService extends ImportCsvService
 		$visitor = null;
 
 		if (self::EXCLUSIVE != $this->method) {
-			try {
-				$visitor = $this->repository()->findByEmailAndSite($data['email'], $this->getSite()->id);
-				$visitor->setAttributes($data);
-			} catch (RecordNotFoundException $e) {
-			}
+			$visitor = $this->repository()->findByEmailAndSite($data['email'], $this->getSite()->id);
 		}
 
-		if (!$visitor) {
+		if ($visitor) {
+			$visitor->setAttributes($data);
+		} else {
 			$visitor = $this->buildVisitor($data);
 		}
 

--- a/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/ImportVisitorsCsvService.php
@@ -12,7 +12,7 @@ class ImportVisitorsCsvService extends ImportCsvService
 {
 	protected $repository;
 	protected $site;
-	protected $passwordStrategy = VisitorPasswordGenerationService::RANDOM_PASSWORD;
+	protected $passwordStrategy = VisitorPasswordGenerationService::DEFAULT_PASSWORD;
 
 	public function import($options)
 	{
@@ -143,7 +143,12 @@ class ImportVisitorsCsvService extends ImportCsvService
 			'layout' => 'mail',
 			'data' =>  $data,
 		));
-		$this->logger()->info("sending email to : {$data['email']}");
+
+		$this->logger()->info("sending visitor invite email", [
+			'email' => $data['email'],
+			'password' => $data['password'],
+		]);
+
 		return $mailer->send();
 	}
 }

--- a/sitebuilder/lib/meumobi/sitebuilder/services/Service.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/Service.php
@@ -4,14 +4,12 @@ namespace meumobi\sitebuilder\services;
 
 use meumobi\sitebuilder\Logger;
 
-abstract class Service
+class Service
 {
 	const PRIORITY_LOW = 0;
 	const PRIORITY_HIGH = 1;
 
 	protected $options;
-
-	abstract public function call();
 
 	public function __construct(array $options = []) {
 		$this->options = $options;

--- a/sitebuilder/script/import_visitors.php
+++ b/sitebuilder/script/import_visitors.php
@@ -5,14 +5,15 @@ use meumobi\sitebuilder\services\ImportVisitorsCsvService;
 
 require dirname(__DIR__) . '/config/cli.php';
 
-$options = getopt('f:s:', ['exclusive','password-strategy::']);
+$options = getopt('f:s:', ['password-strategy::', 'exclusive', 'resend']);
 
 $site = Model::load('Sites')->firstById($options['s']);
 
 require 'segments/' . $site->segment . '/config.php';
+$options['resend'] = isset($options['resend']);
 $import = new ImportVisitorsCsvService();
 if (isset($options['exclusive'])) $import->setMethod(ImportVisitorsCsvService::EXCLUSIVE);
 if (@$options['password-strategy']) $import->setPasswordStrategy($options['password-strategy']);
 $import->setSite($site);
 $import->setFile($options['f']);
-echo $import->import();
+echo $import->import($options);

--- a/sitebuilder/script/import_visitors.php
+++ b/sitebuilder/script/import_visitors.php
@@ -1,9 +1,11 @@
 <?php
+
 use meumobi\sitebuilder\services\ImportVisitorsCsvService;
+use meumobi\sitebuilder\services\VisitorPasswordGenerationService;
 
 require dirname(__DIR__) . '/config/cli.php';
 
-$options = getopt(null, ['site:', 'import-file:', 'password-strategy:', 'exclusive', 'resend']);
+$options = getopt(null, ['site:', 'import-file:', 'auto-password', 'exclusive', 'resend-invite']);
 
 //TODO use ParamsValidator after it be available on master
 if (isset($options['import-file']) && isset($options['site'])) {
@@ -11,10 +13,10 @@ if (isset($options['import-file']) && isset($options['site'])) {
 
 	require 'segments/' . $site->segment . '/config.php';
 
-	$options['resend'] = isset($options['resend']);
+	$options['resend'] = isset($options['resend-invite']);
 	$import = new ImportVisitorsCsvService();
 	if (isset($options['exclusive'])) $import->setMethod(ImportVisitorsCsvService::EXCLUSIVE);
-	if (isset($options['password-strategy'])) $import->setPasswordStrategy($options['password-strategy']);
+	if (isset($options['auto-password'])) $import->setPasswordStrategy(VisitorPasswordGenerationService::RANDOM_PASSWORD);
 	$import->setSite($site);
 	$import->setFile($options['import-file']);
 	echo $import->import($options);

--- a/sitebuilder/script/import_visitors.php
+++ b/sitebuilder/script/import_visitors.php
@@ -1,19 +1,37 @@
 <?php
-use meumobi\sitebuilder\repositories\VisitorsRepository;
-use meumobi\sitebuilder\entities\Visitor;
 use meumobi\sitebuilder\services\ImportVisitorsCsvService;
 
 require dirname(__DIR__) . '/config/cli.php';
 
-$options = getopt('f:s:', ['password-strategy::', 'exclusive', 'resend']);
+$options = getopt(null, ['site:', 'import-file:', 'password-strategy:', 'exclusive', 'resend']);
 
-$site = Model::load('Sites')->firstById($options['s']);
+//TODO use ParamsValidator after it be available on master
+if (isset($options['import-file']) && isset($options['site'])) {
+	$site = Model::load('Sites')->firstById($options['site']);
 
-require 'segments/' . $site->segment . '/config.php';
-$options['resend'] = isset($options['resend']);
-$import = new ImportVisitorsCsvService();
-if (isset($options['exclusive'])) $import->setMethod(ImportVisitorsCsvService::EXCLUSIVE);
-if (@$options['password-strategy']) $import->setPasswordStrategy($options['password-strategy']);
-$import->setSite($site);
-$import->setFile($options['f']);
-echo $import->import($options);
+	require 'segments/' . $site->segment . '/config.php';
+
+	$options['resend'] = isset($options['resend']);
+	$import = new ImportVisitorsCsvService();
+	if (isset($options['exclusive'])) $import->setMethod(ImportVisitorsCsvService::EXCLUSIVE);
+	if (isset($options['password-strategy'])) $import->setPasswordStrategy($options['password-strategy']);
+	$import->setSite($site);
+	$import->setFile($options['import-file']);
+	echo $import->import($options);
+} else {
+	echo <<<'EOL'
+usage: php import_visitors.php OPTIONS
+import site visitors from a csv file
+OPTIONS:
+	MANDATORY:
+		--import-file: csv file path
+		--site: site id
+	OPTIONAL:
+		--password-strategy default|random: if default the site slug will be used as password
+		--exclusive: removes previous visitors before import
+		--resend: send invite email to all imported visitors, including the already created ones
+EXAMPLE:
+$php sitebuilder/script/import_visitors.php --resend --exclusive --site 234 --import-file tmp/visitors.csv --password-strategy random
+
+EOL;
+}


### PR DESCRIPTION
The visitor import was failing because of an exception throwed if some imported visitor had an invalid email. To prevent this, the visitor is validated using the VisitorsPersistenceValidator before try to import it.

The import_visitors options had been renamed and updated to be consistent with the
check_import_visitors script.

Prevents sending invite email if the visitor already have logged in.

closes #133 and #146.

Depends of PR #166 