### PR TITLE
Set correct timezone for visitor last login date

### DIFF
--- a/sitebuilder/app/controllers/api/ApiController.php
+++ b/sitebuilder/app/controllers/api/ApiController.php
@@ -4,16 +4,16 @@ namespace app\controllers\api;
 
 require_once 'app/models/sites.php';
 
-use lithium\util\Inflector;
-use lithium\storage\Session;
-use meumobi\sitebuilder\Site;
-use meumobi\sitebuilder\repositories\VisitorsRepository;
-use meumobi\sitebuilder\entities\Visitor;
-use meumobi\sitebuilder\Logger;
-use DateTime;
 use Config;
-use Model;
+use DateTime;
 use MeuMobi;
+use Model;
+use lithium\storage\Session;
+use lithium\util\Inflector;
+use meumobi\sitebuilder\Logger;
+use meumobi\sitebuilder\Site;
+use meumobi\sitebuilder\entities\Visitor;
+use meumobi\sitebuilder\repositories\VisitorsRepository;
 
 class ApiController extends \lithium\action\Controller {
 	protected $beforeFilter = [

--- a/sitebuilder/app/controllers/api/ApiController.php
+++ b/sitebuilder/app/controllers/api/ApiController.php
@@ -262,7 +262,7 @@ class ApiController extends \lithium\action\Controller {
 
 		if ($this->visitor) {
 			if ($this->visitor->isPasswordValid() || $allowExpired) {
-				$this->visitor->setLastLogin(date('Y-m-d H:i:s'));
+				$this->visitor->setLastLogin(new DateTime('NOW'));
 				$repository->update($this->visitor);
 			} else {
 				throw new ForbiddenException();

--- a/sitebuilder/app/controllers/api/VisitorsController.php
+++ b/sitebuilder/app/controllers/api/VisitorsController.php
@@ -4,6 +4,7 @@ namespace app\controllers\api;
 
 require_once 'lib/mailer/Mailer.php';
 
+use DateTime;
 use I18n;
 use Mailer;
 use MeuMobi;
@@ -56,7 +57,7 @@ class VisitorsController extends ApiController
 				]);
 			}
 
-			$visitor->setLastLogin(date('Y-m-d H:i:s'));
+			$visitor->setLastLogin(new DateTime('NOW'));
 			$repository->update($visitor);
 
 			$response += [

--- a/sitebuilder/app/controllers/api/VisitorsController.php
+++ b/sitebuilder/app/controllers/api/VisitorsController.php
@@ -14,8 +14,8 @@ use meumobi\sitebuilder\entities\VisitorDevice;
 use meumobi\sitebuilder\presenters\api\VisitorPresenter;
 use meumobi\sitebuilder\repositories\RecordNotFoundException;
 use meumobi\sitebuilder\repositories\VisitorsRepository;
-use meumobi\sitebuilder\services\ResetVisitorPassword;
 use meumobi\sitebuilder\services\CreateOrUpdateDevice;
+use meumobi\sitebuilder\services\ResetVisitorPassword;
 
 class VisitorsController extends ApiController
 {

--- a/sitebuilder/app/views/visitors/index.htm.php
+++ b/sitebuilder/app/views/visitors/index.htm.php
@@ -44,7 +44,7 @@
 									<span class="badge"><?= $group ?></span>
 								<?php endforeach ?>
 							</td>
-							<td><?= $visitor->lastLogin() ?></td>
+							<td><?= $visitor->lastLogin() ? $visitor->lastLogin()->format('Y-m-d H:i:s') : null ?></td>
 						</tr>
 						<?php endforeach; ?>
 				</tbody>

--- a/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
@@ -2,12 +2,12 @@
 
 namespace meumobi\sitebuilder\entities;
 
-use meumobi\sitebuilder\entities\VisitorDevice;
-use meumobi\sitebuilder\repositories\RecordNotFoundException;
-use meumobi\sitebuilder\Site;
+use DateTimeZone;
 use MongoId;
 use Security;
-use DateTimeZone;
+use meumobi\sitebuilder\Site;
+use meumobi\sitebuilder\entities\VisitorDevice;
+use meumobi\sitebuilder\repositories\RecordNotFoundException;
 
 class Visitor extends Entity
 {

--- a/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
@@ -7,6 +7,7 @@ use meumobi\sitebuilder\repositories\RecordNotFoundException;
 use meumobi\sitebuilder\Site;
 use MongoId;
 use Security;
+use DateTimeZone;
 
 class Visitor extends Entity
 {
@@ -87,6 +88,9 @@ class Visitor extends Entity
 
 	public function setLastLogin($lastLogin)
 	{
+		if ($lastLogin) {
+			$lastLogin->setTimezone(new DateTimeZone($this->site()->timezone));
+		}
 		$this->lastLogin = $lastLogin;
 	}
 

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
@@ -2,19 +2,17 @@
 
 namespace meumobi\sitebuilder\repositories;
 
-use meumobi\sitebuilder\entities\Visitor;
-use meumobi\sitebuilder\entities\VisitorDevice;
-
 use FileUpload;
 use Filesystem;
 use MongoClient;
-use MongoId;
 use MongoDate;
+use MongoId;
 use Security;
+use meumobi\sitebuilder\entities\Visitor;
+use meumobi\sitebuilder\entities\VisitorDevice;
 
 class VisitorsRepository extends Repository
 {
-
 	public function all()
 	{
 		return $this->hydrateSet($this->collection()->find());

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
@@ -9,6 +9,7 @@ use FileUpload;
 use Filesystem;
 use MongoClient;
 use MongoId;
+use MongoDate;
 use Security;
 
 class VisitorsRepository extends Repository
@@ -116,6 +117,8 @@ class VisitorsRepository extends Repository
 		$data['devices'] = array_map(function($d) {
 			return new VisitorDevice($d);
 		}, $data['devices']);
+		$data['last_login'] = $data['last_login'] ? $data['last_login']->toDateTime() : null;
+
 		return new visitor($data);
 	}
 
@@ -128,7 +131,7 @@ class VisitorsRepository extends Repository
 			'site_id' => $object->siteId(),
 			'hashed_password' => $object->hashedPassword(),
 			'auth_token' => $object->authToken(),
-			'last_login' => $object->lastLogin(),
+			'last_login' => $object->lastLogin() ? new MongoDate($object->lastLogin()->getTimestamp()) : null,
 			'should_renew_password' => $object->shouldRenewPassword(),
 			'devices' => array_map(function($d) {
 				return [


### PR DESCRIPTION
The timezone used in the last_login was based on the server, not on the site config.
because of this the visitors dashboard time of last_login was wrong . Updates the
last_login to use the site setting.

closes #147