### PR TITLE
Add created and modified fields to Visitors

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
@@ -17,10 +17,12 @@ class Visitor extends Entity
 	protected $lastName;
 	protected $hashedPassword;
 	protected $authToken;
-	protected $lastLogin;
 	protected $shouldRenewPassword = false;
 	protected $devices = [];
 	protected $groups = [];
+	protected $lastLogin;
+	protected $created;
+	protected $modified;
 
 	public function siteId()
 	{
@@ -92,6 +94,26 @@ class Visitor extends Entity
 			$lastLogin->setTimezone(new DateTimeZone($this->site()->timezone));
 		}
 		$this->lastLogin = $lastLogin;
+	}
+
+	public function created()
+	{
+		return $this->created;
+	}
+
+	public function setCreated($created)
+	{
+		$this->created = $created;
+	}
+
+	public function modified()
+	{
+		return $this->modified;
+	}
+
+	public function setModified($modified)
+	{
+		$this->modified = $modified;
 	}
 
 	public function shouldRenewPassword()

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
@@ -2,6 +2,7 @@
 
 namespace meumobi\sitebuilder\repositories;
 
+use DateTime;
 use FileUpload;
 use Filesystem;
 use MongoClient;
@@ -99,6 +100,8 @@ class VisitorsRepository extends Repository
 
 	public function create($visitor)
 	{
+		$visitor->setCreated(new DateTime('NOW'));
+		$visitor->setModified(new DateTime('NOW'));
 		$data = $this->dehydrate($visitor);
 		$result = $this->collection()->insert($data);
 		$visitor->setId($data['_id']);
@@ -109,6 +112,7 @@ class VisitorsRepository extends Repository
 	public function update($visitor)
 	{
 		$criteria = ['_id' => new MongoId($visitor->id())];
+		$visitor->setModified(new DateTime('NOW'));
 		$data = $this->dehydrate($visitor);
 
 		if ($this->collection()->update($criteria, $data)) {
@@ -129,6 +133,8 @@ class VisitorsRepository extends Repository
 			return new VisitorDevice($d);
 		}, $data['devices']);
 		$data['last_login'] = $data['last_login'] ? $data['last_login']->toDateTime() : null;
+		$data['created'] = $data['created'] ? $data['created']->toDateTime() : null;
+		$data['modified'] = $data['modified'] ? $data['modified']->toDateTime() : null;
 
 		return new visitor($data);
 	}
@@ -143,6 +149,8 @@ class VisitorsRepository extends Repository
 			'hashed_password' => $object->hashedPassword(),
 			'auth_token' => $object->authToken(),
 			'last_login' => $object->lastLogin() ? new MongoDate($object->lastLogin()->getTimestamp()) : null,
+			'created' => $object->created() ? new MongoDate($object->created()->getTimestamp()) : null,
+			'modified' => $object->modified() ? new MongoDate($object->modified()->getTimestamp()) : null,
 			'should_renew_password' => $object->shouldRenewPassword(),
 			'devices' => array_map(function($d) {
 				return [


### PR DESCRIPTION
Add created and modified fields to Visitors entity.
This will give some feedback on when the visitors had been created or updated, that will be useful for example, to debug the visitors import, know if a visitor has successfully created or updated.

closes #7

Depends of PR #169