### PR TITLE
Fix segments wrong icon colors

### DIFF
--- a/segments/agencia3/public/styles/segment.css
+++ b/segments/agencia3/public/styles/segment.css
@@ -112,11 +112,14 @@ body {
 div.theme-picker > ul > li.selected {
   box-shadow: 0 0 0 3px #c2cb1e inset; }
 
-div.dashboard .list li .link .icon
-, div.dashboard .list li:hover .arrow
-, .placeholder-links a img {
-  background-color: #c2cb1e; }
+.featured-list li .link .icon,
+.placeholder-links a img {
+  background-color: #c2cb1e;
+}
 
-div.dashboard .list li .link h3,
+.featured-list li .link h3,
+.featured-list > li .link .icons,
+.featured-list li:hover .arrow,
 div.dashboard .domain a {
-  color: #c2cb1e; }
+  color: #c2cb1e;;
+}

--- a/segments/comunique-se/public/styles/segment.css
+++ b/segments/comunique-se/public/styles/segment.css
@@ -114,9 +114,12 @@ div.theme-picker > ul > li.selected {
 
 .featured-list li .link .icon,
 .placeholder-links a img {
-  background-color: #f38021; }
+  background-color: #f38021;
+}
 
 .featured-list li .link h3,
+.featured-list > li .link .icons,
 .featured-list li:hover .arrow,
 div.dashboard .domain a {
-  color: #f38021; }
+  color: #f38021;
+}

--- a/segments/investors/public/styles/segment.css
+++ b/segments/investors/public/styles/segment.css
@@ -113,11 +113,13 @@ div.theme-picker > ul > li.selected {
   box-shadow: 0 0 0 3px #2f3e6e inset; }
 
 .featured-list li .link .icon
-
 , .placeholder-links a img {
-  background-color: #2f3e6e; }
+  background-color: #2f3e6e;
+}
 
 .featured-list li .link h3,
-.featured-list > li .link .icons, .featured-list li:hover .arrow,
+.featured-list > li .link .icons,
+.featured-list li:hover .arrow,
 div.dashboard .domain a {
-  color: #2f3e6e; }
+  color: #2f3e6e;
+}

--- a/segments/tibox/public/styles/segment.css
+++ b/segments/tibox/public/styles/segment.css
@@ -114,9 +114,12 @@ div.theme-picker > ul > li.selected {
 
 .featured-list li .link .icon,
 .placeholder-links a img {
-  background-color: #d71921; }
+  background-color: #d71921;
+}
 
 .featured-list li .link h3,
+.featured-list > li .link .icons,
 .featured-list li:hover .arrow,
 div.dashboard .domain a {
-  color: #d71921; }
+  color: #d71921;
+}

--- a/sitebuilder/assets/styles/segment.scss
+++ b/sitebuilder/assets/styles/segment.scss
@@ -143,6 +143,7 @@ div.theme-picker > ul > li.selected {
 }
 
 .featured-list li .link h3,
+.featured-list li .link .icons,
 .featured-list li:hover .arrow,
 div.dashboard .domain a {
 	color: $main-color;


### PR DESCRIPTION
Overwrite default icon colors on the custom segment style template,
to fix the wrong colors in custom segment layouts.

closes #164