### PR TITLE
Add migration to convert visitors.last_login from string to Date

### DIFF
--- a/sitebuilder/db/migrations/20150825234300_convert_last_login_to_date.php
+++ b/sitebuilder/db/migrations/20150825234300_convert_last_login_to_date.php
@@ -1,0 +1,20 @@
+<?php
+
+use lithium\data\Connections;
+
+class ConvertLastLoginToDate
+{
+	public static function migrate($connection)
+	{
+		$connection = Connections::get('default')->connection;
+
+		$command = 'return db.visitors.find().forEach(function(visitor) {
+			if (visitor.last_login) {
+				visitor.last_login = new Date(visitor.last_login);
+				db.visitors.save(visitor);
+			}
+		});';
+
+		$connection->execute($command);
+	}
+}


### PR DESCRIPTION
The Visitor entity was updated to use the correct field type for dates, because of this the string dates in the previous registered visitors need to be converted from to date objects.

Closes #193