### PR TITLE
Set correct status for errors in API /mail request

### DIFF
--- a/sitebuilder/app/controllers/api/InvalidArgumentException.php
+++ b/sitebuilder/app/controllers/api/InvalidArgumentException.php
@@ -4,5 +4,6 @@ namespace app\controllers\api;
 
 class InvalidArgumentException extends \InvalidArgumentException
 {
-	public $status = 422;
+	public $status = 400;
+	protected $message = 'Bad Request';
 }

--- a/sitebuilder/app/controllers/api/MailController.php
+++ b/sitebuilder/app/controllers/api/MailController.php
@@ -19,7 +19,7 @@ class MailController extends ApiController
 		if (!$this->request->get('data:name') ||
 			!$this->request->get('data:mail') ||
 			!$this->request->get('data:message')) {
-			return array('error' => 'missing parameters');
+			throw new InvalidArgumentException('missing parameters');
 		}
 
 		$site = $this->site();


### PR DESCRIPTION
The status 200 was returned when a request with invalid parameters was sent to
POST /mail.

Now the response returns the correct message with the correct status 400, if an
request is invalid.

Closes #168