### PR TITLE
Extract reset password email from User model

### DIFF
--- a/config/locales/pt.yaml
+++ b/config/locales/pt.yaml
@@ -268,7 +268,7 @@
 'Your password needs to be at least 6 characters long.': 'Sua senha precisa ter ao menos 6 caracteres'
 '[MeuMobi] Account Confirmation': '[MeuMobi] Confirmação de Conta'
 '[MeuMobi] Category import scheduled': '[MeuMobi] Importação da categoria agendada'
-'[MeuMobi] Reset Password Request': '[MeuMobi] Recadastramento de Senha'
+'[%s] Reset Password Request': '[%s] Recadastramento de Senha'
 'add item': 'adicionar item'
 'add more location? get a Store Locator': 'seu negócio possui multiplas localidades?'
 'add one more domain': 'adicionar outro domínio'

--- a/sitebuilder/app/models/users.php
+++ b/sitebuilder/app/models/users.php
@@ -1,9 +1,10 @@
 <?php
 
+require_once 'lib/mailer/Mailer.php';
+
 use lithium\storage\Session;
 use lithium\util\Validator;
-
-require_once 'lib/mailer/Mailer.php';
+use meumobi\sitebuilder\services\SendForgottenUserPasswordMail;
 
 class Users extends AppModel
 {
@@ -161,11 +162,14 @@ class Users extends AppModel
 	{
 		if (!empty($email)) {
 			$user = $this->firstByEmail($email);
+
 			if ($user) {
-				$user->sendForgottenPasswordMail();
+				$service = new SendForgottenUserPasswordMail();
+				$service->send($user);
 			} else {
 				$this->errors['email'] = 'The e-mail is not registered in MeuMobi';
 			}
+
 		} else {
 			$this->errors['email'] = 'You need to provide your e-mail';
 		}
@@ -349,26 +353,6 @@ class Users extends AppModel
 					'user' => $this,
 					'title' => s('[MeuMobi] Account Confirmation')
 				));
-		}
-	}
-
-	protected function sendForgottenPasswordMail()
-	{
-		if (!Config::read('Mail.preventSending')) {
-			$segment = MeuMobi::currentSegment();
-
-			$mailer = new Mailer(array(
-				'from' => $segment->email,
-				'to' => array($this->email => $this->fullname()),
-				'subject' => s('[MeuMobi] Reset Password Request'),
-				'views' => array('text/html' => 'users/forgot_password_mail.htm'),
-				'layout' => 'mail',
-				'data' => array(
-					'user' => $this,
-					'title' => s('[MeuMobi] Reset Password Request')
-				)
-			));
-			$mailer->send ();
 		}
 	}
 

--- a/sitebuilder/app/views/users/forgot_password_mail.htm.php
+++ b/sitebuilder/app/views/users/forgot_password_mail.htm.php
@@ -1,6 +1,6 @@
-<p style="padding: 0 20px; font-size: small">
-    <?php echo s('Hi, <b>%s</b>. <br/><br/>You have requested the reset of your MeuMobi password. In order to do that you should click on link below.', $user->firstname()) ?>
+<p>
+	<?= s('Hi, <b>%s</b>. <br/><br/>You have requested the reset of your MeuMobi password. In order to do that you should click on link below.', $user->firstname()) ?>
 </p>
-<p style="padding: 0 20px">
-    <?php echo $this->html->link($url = Mapper::url('/users/reset_password/' . $user->id . '/' . $user->token, true), $url, array('style' => 'color: #FF0000')) ?>
+<p>
+	<?= $this->html->link($url = Mapper::url('/users/reset_password/' . $user->id . '/' . $user->token, true), $url) ?>
 </p>

--- a/sitebuilder/lib/mailer/Mailer.php
+++ b/sitebuilder/lib/mailer/Mailer.php
@@ -75,7 +75,7 @@ class Mailer {
             $mailer = Swift_Mailer::newInstance($this->transport());
             return $mailer->send($message);
         else:
-            Logger::error('mailer', $message);
+            Logger::debug('mailer', $message);
         endif;
     }
 }

--- a/sitebuilder/lib/meumobi/sitebuilder/services/SendForgottenUserPasswordMail.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/SendForgottenUserPasswordMail.php
@@ -21,7 +21,7 @@ class SendForgottenUserPasswordMail
 			'data' => [
 				'user' => $user,
 				'site' => $user->site(),
-				'title' => s('[%] Reset Password Request', $segment->title)
+				'title' => s('[%s] Reset Password Request', $segment->title)
 			]
 		]);
 

--- a/sitebuilder/lib/meumobi/sitebuilder/services/SendForgottenUserPasswordMail.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/SendForgottenUserPasswordMail.php
@@ -1,0 +1,30 @@
+<?php
+namespace meumobi\sitebuilder\services;
+
+use Mailer;
+use MeuMobi;
+use meumobi\sitebuilder\Logger;
+use meumobi\sitebuilder\validators\ParamsValidator;
+
+class SendForgottenUserPasswordMail
+{
+	public function send($user)
+	{
+		$segment = MeuMobi::currentSegment();
+
+		$mailer = new Mailer([
+			'from' => $segment->email,
+			'to' => [$user->email => $user->fullname()],
+			'subject' => s('[%s] Reset Password Request', $segment->title),
+			'views' => ['text/html' => 'users/forgot_password_mail.htm'],
+			'layout' => 'mail',
+			'data' => [
+				'user' => $user,
+				'site' => $user->site(),
+				'title' => s('[%] Reset Password Request', $segment->title)
+			]
+		]);
+
+		$mailer->send();
+	}
+}


### PR DESCRIPTION
Extract the email from the User in the service SendForgottenUserPasswordMail. 
Because the Model already has a lot of responsibilities, but send email isn't one of them.

A warning message was removed in the process by passing the user site to the email
parameters.

closes #173