### PR TITLE
Make Visitors authentication case insensitive

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/entities/Visitor.php
@@ -34,6 +34,11 @@ class Visitor extends Entity
 		return $this->email;
 	}
 
+	public function setEmail($email)
+	{
+		$this->email = strtolower(trim($email));
+	}
+
 	public function firstName()
 	{
 		return $this->firstName;

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/VisitorsRepository.php
@@ -45,7 +45,9 @@ class VisitorsRepository extends Repository
 
 	public function findByEmail($email)
 	{
-		$result = $this->collection()->findOne(['email' => $email]);
+		$result = $this->collection()->findOne([
+			'email' => strtolower(trim($email))
+		]);
 
 		if ($result) {
 			return $this->hydrate($result);
@@ -57,7 +59,7 @@ class VisitorsRepository extends Repository
 	public function findByEmailAndSite($email, $siteId)
 	{
 		$result = $this->collection()->findOne([
-			'email' => trim($email),
+			'email' => strtolower(trim($email)),
 			'site_id' => (int) $siteId,
 		]);
 
@@ -70,7 +72,7 @@ class VisitorsRepository extends Repository
 	public function findForAuthentication($siteId, $email, $password)
 	{
 		$conditions = [
-			'email' => $email,
+			'email' => strtolower(trim($email)),
 			'hashed_password' => Security::hash($password, 'sha1')
 		];
 


### PR DESCRIPTION
Trim and lower case the visitor email because the email is not case sensitive
and the outer spaces are not considered.

closes #130