### PR TITLE
Fix missing extension id in the Update Feeds and Events log

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/services/CreateItem.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/CreateItem.php
@@ -65,7 +65,7 @@ class CreateItem
 
 	protected function addMediaFileSize($item)
 	{
-		$hasMedias = count($item->medias->to('array'));
+		$hasMedias = $item->medias && count($item->medias->to('array'));
 
 		if ($hasMedias) {
 			WorkerManager::enqueue('media_filesize', ['item_id' => $item->id()]);

--- a/sitebuilder/lib/meumobi/sitebuilder/services/CreateItem.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/CreateItem.php
@@ -72,6 +72,7 @@ class CreateItem
 		} else {
 			Logger::debug('items', 'not creating media_filesize job', [
 				'item_id' => $item->id(),
+				'site_id' => $item->site_id,
 				'reason' => 'item has no media',
 			]);
 		}
@@ -108,6 +109,7 @@ class CreateItem
 		} else {
 			Logger::debug('items', 'not creating push_notification job', [
 				'item_id' => $item->id(),
+				'site_id' => $item->site_id,
 				'reason' => [
 					'published' => $item->is_published,
 					'push_enabled_in_category' => $category->notification

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
@@ -40,7 +40,7 @@ class UpdateEventsFeedWorker
 			} catch (Exception $e) {
 				$stats['total_failed_feeds'] += 1;
 				$stats['failed_feeds'][] = [
-					'extension_id' => (string) $extension->id,
+					'extension_id' => (string) $extension->_id,
 					'category_id' => $extension->category_id,
 					'site_id' => $extension->site_id,
 					'error' => $e->getMessage(),

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateFeedsWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateFeedsWorker.php
@@ -40,7 +40,7 @@ class UpdateFeedsWorker
 			} catch (Exception $e) {
 				$stats['total_failed_feeds'] += 1;
 				$stats['failed_feeds'][] = [
-					'extension_id' => (string) $extension->id,
+					'extension_id' => (string) $extension->_id,
 					'category_id' => $extension->category_id,
 					'site_id' => $extension->site_id,
 					'error' => $e->getMessage(),


### PR DESCRIPTION
Fix the typo that causes the missing extension id in the logs.

Also Update addMediaFileSize conditional that checks if an item has any media.

Closes #200