### PR TITLE
Prevent import item from invalid site

### DIFF
--- a/sitebuilder/app/controllers/api/ItemsController.php
+++ b/sitebuilder/app/controllers/api/ItemsController.php
@@ -8,9 +8,9 @@ use Inflector;
 use Model;
 use View;
 use app\models\Items;
-use app\models\RecordNotFoundException;
 use lithium\core\Object;
 use meumobi\sitebuilder\presenters\api\RssItemPresenter;
+use meumobi\sitebuilder\repositories\RecordNotFoundException;
 use meumobi\sitebuilder\services\CreateItem;
 use meumobi\sitebuilder\services\UpdateItem;
 

--- a/sitebuilder/app/models/Items.php
+++ b/sitebuilder/app/models/Items.php
@@ -12,6 +12,7 @@ use GoogleGeocoding;
 use GeocodingException;
 use OverQueryLimitException;
 use meumobi\sitebuilder\services\UpdateFeedsService;
+use meumobi\sitebuilder\repositories\RecordNotFoundException;
 use meumobi\sitebuilder\WorkerManager;
 use lithium\util\Collection;
 
@@ -489,7 +490,7 @@ class Items extends \lithium\data\Model {
 			$classname = '\app\models\items\\' . Inflector::camelize($result->type);
 			return $classname::find('first', $params['options']);
 		} else {
-			throw new \app\models\RecordNotFoundException('item not found');
+			throw new RecordNotFoundException('item not found');
 		}
 	}
 

--- a/sitebuilder/app/models/RecordNotFoundException.php
+++ b/sitebuilder/app/models/RecordNotFoundException.php
@@ -1,8 +1,0 @@
-<?php
-
-namespace app\models;
-
-class RecordNotFoundException extends \Exception
-{
-	public $status = 404;
-}

--- a/sitebuilder/app/models/app_model.php
+++ b/sitebuilder/app/models/app_model.php
@@ -1,5 +1,7 @@
 <?php
 
+use meumobi\sitebuilder\repositories\RecordNotFoundException;
+
 class AppModel extends Model {
     protected $displayField = 'title';
 
@@ -25,7 +27,7 @@ class AppModel extends Model {
 
         if(is_null($first)) {
             $class = get_class($this);
-            throw new \app\models\RecordNotFoundException("{$class} with id={$id} not found");
+            throw new RecordNotFoundException("{$class} with id={$id} not found");
         }
         else {
             return $first;

--- a/sitebuilder/app/models/categories.php
+++ b/sitebuilder/app/models/categories.php
@@ -92,6 +92,11 @@ class Categories extends AppModel
 		return array_reverse($breadcrumbs);
 	}
 
+	public function site()
+	{
+		return Model::load('Sites')->firstById($this->site_id);
+	}
+
 	public function parent()
 	{
 		if ($this->parent_id && $this->validParent($this->parent_id)) {
@@ -201,7 +206,7 @@ class Categories extends AppModel
 	protected function getItemType($data)
 	{
 		if (is_null($this->id)) {
-			$site = Model::load('Sites')->firstById($this->site_id);
+			$site = $this->site();
 			$items = (array) $site->itemTypes();
 
 			if (!array_key_exists('type', $data) || !in_array($data['type'], $items)) {
@@ -294,7 +299,7 @@ class Categories extends AppModel
 			$parent->save();
 		}
 
-		$site = Model::load('Sites')->firstById($this->site_id);
+		$site = $this->site();
 		$site->modified = $date;
 		$site->save();
 		} catch (Exception $e) {
@@ -315,7 +320,7 @@ class Categories extends AppModel
 				$parent->save();
 			}
 
-			$site = Model::load('Sites')->firstById($self->site_id);
+			$site = $self->site();
 			$site->updated = $date;
 			$site->save();
 		} catch (Exception $e) {

--- a/sitebuilder/lib/meumobi/sitebuilder/roles/Updatable.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/roles/Updatable.php
@@ -1,0 +1,51 @@
+<?php
+namespace meumobi\sitebuilder\roles;
+
+use Exception;
+use Inflector;
+use app\models\Extensions;
+use meumobi\sitebuilder\repositories\RecordNotFoundException;
+use meumobi\sitebuilder\Logger;
+
+trait Updatable
+{
+	public function getExtensionsByPriorityAndType($priority, $type)
+	{
+		$classname = '\app\models\extensions\\' . Inflector::camelize($type);
+
+		return $classname::find('all', [
+			'conditions' => [
+				'extension' => $type,
+				'enabled' => 1,
+				'priority' => $priority,
+			],
+		]);
+	}
+
+	public function getCategory($extension)
+	{
+		try {
+			$category = Extensions::category($extension);
+			$category->site();
+
+			return $category;
+		} catch (RecordNotFoundException $e) {
+			$this->disableExtension($extension, $e->getMessage());
+
+			throw new Exception($e->getMessage());
+		}
+	}
+
+	public function disableExtension($extension, $reason)
+	{
+		$extension->enabled = 0;
+		$extension->save();
+
+		Logger::info('extensions', 'category extension disabled', [
+			'extension_id' => (string) $extension->_id,
+			'category_id' => $extension->category_id,
+			'site_id' => $extension->site_id,
+			'reason' => $reason,
+		]);
+	}
+}

--- a/sitebuilder/lib/meumobi/sitebuilder/validators/ItemsPersistenceValidator.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/validators/ItemsPersistenceValidator.php
@@ -3,7 +3,7 @@ namespace meumobi\sitebuilder\validators;
 
 use Model;
 use Validation;
-use app\models\RecordNotFoundException;
+use meumobi\sitebuilder\repositories\RecordNotFoundException;
 
 class ItemsPersistenceValidator implements Validator
 {

--- a/sitebuilder/lib/meumobi/sitebuilder/validators/ItemsPersistenceValidator.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/validators/ItemsPersistenceValidator.php
@@ -1,10 +1,14 @@
 <?php
 namespace meumobi\sitebuilder\validators;
 
+use Model;
+use Validation;
+use app\models\RecordNotFoundException;
+
 class ItemsPersistenceValidator implements Validator
 {
 	/*
-	 * List of validation rules and error messages tokens, since the message 
+	 * List of validation rules and error messages tokens, since the message
 	 * should be the responsibility of the presentation layer.
 	 * http://jeffreypalermo.com/blog/the-fallacy-of-the-always-valid-entity/
 	 */
@@ -52,8 +56,13 @@ class ItemsPersistenceValidator implements Validator
 
 	protected function validSite($siteId, $item)
 	{
-		$category = $item->parent();
-		return $category->site_id == $siteId;
+		try {
+			$site = $item->parent()->site();
+
+			return $site->id == $siteId;
+		} catch (RecordNotFoundException $e) {
+			return false;
+		}
 	}
 
 	protected function validType($type, $item)

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
@@ -3,14 +3,15 @@
 namespace meumobi\sitebuilder\workers;
 
 use Exception;
-use app\models\extensions\EventFeed;
 use meumobi\sitebuilder\Logger;
-use meumobi\sitebuilder\repositories\RecordNotFoundException;
+use meumobi\sitebuilder\roles\Updatable;
 use meumobi\sitebuilder\services\UpdateEventsFeed;
 use meumobi\sitebuilder\validators\ParamsValidator;
 
 class UpdateEventsFeedWorker
 {
+	use Updatable;
+
 	public function perform($params)
 	{
 		list($priority) = ParamsValidator::validate($params, ['priority']);
@@ -28,7 +29,7 @@ class UpdateEventsFeedWorker
 			'priority' => $priority,
 		];
 
-		$extensions = $this->getExtensionsByPriority($priority);
+		$extensions = $this->getExtensionsByPriorityAndType($priority, 'event-feed');
 
 		foreach($extensions as $extension) {
 			try {
@@ -51,31 +52,4 @@ class UpdateEventsFeedWorker
 		$stats['elapsed_time'] = microtime(true) - $start;
 		Logger::info('workers', 'finished updating events feeds', $stats);
 	}
-
-	protected function getExtensionsByPriority($priority)
-	{
-		return EventFeed::find('all', [
-			'conditions' => [
-				'extension' => 'event-feed',
-				'enabled' => 1,
-				'priority' => $priority,
-			],
-		]);
-	}
-
-	protected function getCategory($extension)
-	{
-		try {
-			$category = EventFeed::category($extension);
-			$category->site();
-
-			return $category;
-		} catch (RecordNotFoundException $e) {
-			$extension->enabled = 0;
-			$extension->save();
-
-			throw new Exception($e->getMessage());
-		}
-	}
 }
-

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
@@ -4,8 +4,8 @@ namespace meumobi\sitebuilder\workers;
 
 use Exception;
 use app\models\extensions\EventFeed;
+use app\models\RecordNotFoundException;
 use meumobi\sitebuilder\Logger;
-use meumobi\sitebuilder\repositories\RecordNotFoundException;
 use meumobi\sitebuilder\services\UpdateEventsFeed;
 use meumobi\sitebuilder\validators\ParamsValidator;
 
@@ -66,11 +66,15 @@ class UpdateEventsFeedWorker
 	protected function getCategory($extension)
 	{
 		try {
-			return EventFeed::category($extension);
+			$category = EventFeed::category($extension);
+			$category->site();
+
+			return $category;
 		} catch (RecordNotFoundException $e) {
 			$extension->enabled = 0;
 			$extension->save();
-			throw new Exception('Invalid extension category');
+
+			throw new Exception($e->getMessage());
 		}
 	}
 }

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
@@ -4,8 +4,8 @@ namespace meumobi\sitebuilder\workers;
 
 use Exception;
 use app\models\extensions\EventFeed;
-use app\models\RecordNotFoundException;
 use meumobi\sitebuilder\Logger;
+use meumobi\sitebuilder\repositories\RecordNotFoundException;
 use meumobi\sitebuilder\services\UpdateEventsFeed;
 use meumobi\sitebuilder\validators\ParamsValidator;
 

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateEventsFeedWorker.php
@@ -35,6 +35,7 @@ class UpdateEventsFeedWorker
 			try {
 				$category = $this->getCategory($extension);
 				$updateEventsFeed = new UpdateEventsFeed();
+
 				$stats['categories'][$category->id] =
 					$updateEventsFeed->perform(compact('category', 'extension'));
 				$stats['total_updated_feeds'] += 1;

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateFeedsWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateFeedsWorker.php
@@ -35,6 +35,7 @@ class UpdateFeedsWorker
 			try {
 				$category = $this->getCategory($extension);
 				$updateNewsFeed = new UpdateNewsFeed();
+
 				$stats['categories'][$category->id] =
 					$updateNewsFeed->perform(compact('category', 'extension'));
 				$stats['total_updated_feeds'] += 1;

--- a/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateFeedsWorker.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/workers/UpdateFeedsWorker.php
@@ -4,8 +4,8 @@ namespace meumobi\sitebuilder\workers;
 
 use Exception;
 use app\models\extensions\Rss;
-use meumobi\sitebuilder\Logger;
 use meumobi\sitebuilder\repositories\RecordNotFoundException;
+use meumobi\sitebuilder\Logger;
 use meumobi\sitebuilder\services\UpdateNewsFeed;
 use meumobi\sitebuilder\validators\ParamsValidator;
 
@@ -66,11 +66,15 @@ class UpdateFeedsWorker
 	protected function getCategory($extension)
 	{
 		try {
-			return Rss::category($extension);
+			$category = Rss::category($extension);
+			$category->site();
+
+			return $category;
 		} catch (RecordNotFoundException $e) {
 			$extension->enabled = 0;
 			$extension->save();
-			throw new Exception('Invalid extension category');
+
+			throw new Exception($e->getMessage());
 		}
 	}
 }


### PR DESCRIPTION
On update feed, disable the extension if the site not exists, also update item validation to check if site exists before persist the item.

Checklist:

- [x] No backslash to call class, ie. AVOID "new \DOMXPath" (I recommend to run grep "new \" on files commited)
- [x] Don't put the branch name in the title of the PR neither issue number.
- [x] Updates on commits only concerns the target issue. None other updates should be pushed  
- [x] Each methods does one single task. AVOID multiple tasks on same method. 
- [x] Logs follow actions and are consistent with rest of platform
- [x] All previous comments on existing code have been considered
- [x] Always leave the last comma in a multi-line array (Zend Coding Style)
- [x] I've explained on Issue's comment how did I test it on Integration environment (local tested are irrelevant).
- [x] ... and the most important, I've ran my code

closes #227