### PR TITLE
Load segment yaml strings in command line scripts

### DIFF
--- a/sitebuilder/config/bootstrap.php
+++ b/sitebuilder/config/bootstrap.php
@@ -25,24 +25,29 @@ require_once 'app/models/app_model.php';
 require_once 'app/controllers/app_controller.php';
 require_once 'app/models/meu_mobi.php';
 
+use \lithium\action\Dispatcher;
 
-return function($segment) {
-	require_once 'segments/' . $segment . '/config.php';
-
-	YamlDictionary::dictionary('strings');
-	YamlDictionary::path(APP_ROOT . '/segments/' . $segment);
+return function($segment)
+{
+	loadSegment($segment);
 
 	try {
-		echo \lithium\action\Dispatcher::run(new \lithium\action\Request(array(
+		echo Dispatcher::run(new \lithium\action\Request([
 			'url' => Mapper::here()
-		)));
-//	} catch (SpaghettiException $e) {
-//		echo $e->toString();
+		]));
 	} catch (Exception $e) {
 		Debug::log((string) $e);
 
-//		if (Config::read('Debug.showErrors')) {
+		if (Config::read('Debug.showErrors')) {
 			echo '<pre>', $e, '</pre>';
-	//	}
+		}
 	}
 };
+
+function loadSegment($segment)
+{
+	require_once "segments/$segment/config.php";
+
+	YamlDictionary::dictionary('strings');
+	YamlDictionary::path(APP_ROOT . '/segments/' . $segment);
+}

--- a/sitebuilder/script/create_user.php
+++ b/sitebuilder/script/create_user.php
@@ -14,8 +14,7 @@ $password = array_shift($argv);
 $siteTitle = array_shift($argv);
 $segment = array_shift($argv);
 
-require 'segments/' . $segment . '/config.php';
-
+loadSegment($segment);
 
 $user = new Users();
 $user->cantCreateSite = true;

--- a/sitebuilder/script/import_visitors.php
+++ b/sitebuilder/script/import_visitors.php
@@ -11,7 +11,7 @@ $options = getopt(null, ['site:', 'import-file:', 'auto-password', 'exclusive', 
 if (isset($options['import-file']) && isset($options['site'])) {
 	$site = Model::load('Sites')->firstById($options['site']);
 
-	require 'segments/' . $site->segment . '/config.php';
+	loadSegment($site->segment);
 
 	$options['resend'] = isset($options['resend-invite']);
 	$import = new ImportVisitorsCsvService();

--- a/sitebuilder/script/import_visitors.php
+++ b/sitebuilder/script/import_visitors.php
@@ -12,6 +12,7 @@ if (isset($options['import-file']) && isset($options['site'])) {
 	$site = Model::load('Sites')->firstById($options['site']);
 
 	loadSegment($site->segment);
+	I18n::locale($site->language);
 
 	$options['resend'] = isset($options['resend-invite']);
 	$import = new ImportVisitorsCsvService();
@@ -19,6 +20,7 @@ if (isset($options['import-file']) && isset($options['site'])) {
 	if (isset($options['auto-password'])) $import->setPasswordStrategy(VisitorPasswordGenerationService::RANDOM_PASSWORD);
 	$import->setSite($site);
 	$import->setFile($options['import-file']);
+
 	echo $import->import($options);
 } else {
 	echo <<<'EOL'

--- a/sitebuilder/script/reset_visitor_password.php
+++ b/sitebuilder/script/reset_visitor_password.php
@@ -7,9 +7,12 @@ use meumobi\sitebuilder\services\ResetVisitorPassword;
 
 function updateVisitorPassword($email)
 {
-	$repository = new VisitorsRepository();
-	$visitor = $repository->findByEmail($email);
+	$visitor = getVisitor($email);
 	$service = new ResetVisitorPassword();
+
+	$site = Model::load('Sites')->firstById($visitor->siteId());
+	loadSegment($site->segment);
+	I18n::locale($site->language);
 
 	if ($service->resetPassword($visitor)) {
 		echo "Visitor password successfully updated.\n";
@@ -25,6 +28,8 @@ function getVisitor($email)
 	if (!$visitor) {
 		exit("invalid visitor.\n");
 	}
+
+	return $visitor;
 }
 
 $options = getopt('', ['email:']);

--- a/sitebuilder/script/reset_visitor_password.php
+++ b/sitebuilder/script/reset_visitor_password.php
@@ -1,41 +1,30 @@
 <?php
+require dirname(__DIR__) . '/config/cli.php';
+
 use meumobi\sitebuilder\repositories\VisitorsRepository;
 use meumobi\sitebuilder\entities\Visitor;
-
-require dirname(__DIR__) . '/config/cli.php';
+use meumobi\sitebuilder\services\ResetVisitorPassword;
 
 function updateVisitorPassword($email)
 {
 	$repository = new VisitorsRepository();
 	$visitor = $repository->findByEmail($email);
-	$password = $visitor->setRandomPassword();
-	$repository->update($visitor);
-	echo "Visitor password updated to: $password\n";
-	sendVisitorEmail($visitor, $password);
+	$service = new ResetVisitorPassword();
+
+	if ($service->resetPassword($visitor)) {
+		echo "Visitor password successfully updated.\n";
+	}
+
 }
 
-function sendVisitorEmail($visitor, $password)
+function getVisitor($email)
 {
-	$site = Model::load('Sites')->firstById($visitor->siteId());
-	require 'segments/' . $site->segment . '/config.php';//TODO remove this from here
-	\I18n::locale($site->language);
-	$data =	[
-		'title' => s('[%s]: New password', $site->title),
-		'segment' => \MeuMobi::currentSegment(),
-		'password' => $password,
-		'visitor' => $visitor,
-		'site' => $site,
-	];
-	$mailer = new \Mailer([
-		'from' => $data['segment']->email,
-		'to' => $visitor->email(),
-		'subject' => $data['title'],
-		'views' => ['text/html' => 'visitors/forgot_password_mail.htm'],
-		'layout' => 'mail',
-		'data' =>  $data,
-	]);
-	echo "sending email to : {$visitor->email()}\n";
-	return $mailer->send();
+	$repository = new VisitorsRepository();
+	$visitor = $repository->findByEmail($email);
+
+	if (!$visitor) {
+		exit("invalid visitor.\n");
+	}
 }
 
 $options = getopt('', ['email:']);


### PR DESCRIPTION
Move the segment loading of bootstrap dispatcher to a different method to allow the scripts load the segment yaml files.

Use the ResetVisitorPassword service in the reset_visitor_password script.

Load locale based on site settings on command line scripts.

- [x] No backslash to call class, ie. AVOID "new \DOMXPath" (I recommend to run grep "new \" on files commited)
- [x] Don't put the branch name in the title of the PR neither issue number.
- [x] Updates on commits only concerns the target issue. None other updates should be pushed  
- [x] Each methods does one single task. AVOID multiple tasks on same method. 
- [x] Logs follow actions and are consistent with rest of platform
- [x] All previous comments on existing code have been considered
- [x] Always leave the last comma in a multi-line array (Zend Coding Style)
- [x] I've explained on Issue's comment how did I test it on Integration environment (local tested are irrelevant).
- [x] ... and the most important, I've ran my code

Closes #138, closes #137