### PR TITLE
Translate Datatable list based on user settings

### DIFF
--- a/sitebuilder/app/views/visitors/index.htm.php
+++ b/sitebuilder/app/views/visitors/index.htm.php
@@ -62,4 +62,5 @@
 </div>
 <script>
 	window.visitorGraphData = <?= $visitorGraphDataJson ?>;
+	window.datatableLocaleUrl = '<?= Mapper::url("/scripts/shared/datatable.$language.json") ?>'
 </script>

--- a/sitebuilder/assets/scripts/datatable.en.json
+++ b/sitebuilder/assets/scripts/datatable.en.json
@@ -1,0 +1,25 @@
+
+
+{
+	"sEmptyTable":     "No data available in table",
+	"sInfo":           "Showing _START_ to _END_ of _TOTAL_ entries",
+	"sInfoEmpty":      "Showing 0 to 0 of 0 entries",
+	"sInfoFiltered":   "(filtered from _MAX_ total entries)",
+	"sInfoPostFix":    "",
+	"sInfoThousands":  ",",
+	"sLengthMenu":     "Show _MENU_ entries",
+	"sLoadingRecords": "Loading...",
+	"sProcessing":     "Processing...",
+	"sSearch":         "Search:",
+	"sZeroRecords":    "No matching records found",
+	"oPaginate": {
+		"sFirst":    "First",
+		"sLast":     "Last",
+		"sNext":     "Next",
+		"sPrevious": "Previous"
+	},
+	"oAria": {
+		"sSortAscending":  ": activate to sort column ascending",
+		"sSortDescending": ": activate to sort column descending"
+	}
+}

--- a/sitebuilder/assets/scripts/datatable.pt.json
+++ b/sitebuilder/assets/scripts/datatable.pt.json
@@ -1,0 +1,25 @@
+
+
+{
+    "sEmptyTable": "Nenhum registro encontrado",
+    "sInfo": "Mostrando de _START_ até _END_ de _TOTAL_ registros",
+    "sInfoEmpty": "Mostrando 0 até 0 de 0 registros",
+    "sInfoFiltered": "(Filtrados de _MAX_ registros)",
+    "sInfoPostFix": "",
+    "sInfoThousands": ".",
+    "sLengthMenu": "_MENU_ resultados por página",
+    "sLoadingRecords": "Carregando...",
+    "sProcessing": "Processando...",
+    "sZeroRecords": "Nenhum registro encontrado",
+    "sSearch": "Pesquisar",
+    "oPaginate": {
+        "sNext": "Próximo",
+        "sPrevious": "Anterior",
+        "sFirst": "Primeiro",
+        "sLast": "Último"
+    },
+    "oAria": {
+        "sSortAscending": ": Ordenar colunas de forma ascendente",
+        "sSortDescending": ": Ordenar colunas de forma descendente"
+    }
+}

--- a/sitebuilder/assets/scripts/main.js
+++ b/sitebuilder/assets/scripts/main.js
@@ -648,34 +648,11 @@ $(window).load(function() {
   });
   $('#domains .domain a').click(removeField);
 
-  dataTableLang = {
-    "sEmptyTable": "Nenhum registro encontrado",
-    "sInfo": "Mostrando de _START_ até _END_ de _TOTAL_ registros",
-    "sInfoEmpty": "Mostrando 0 até 0 de 0 registros",
-    "sInfoFiltered": "(Filtrados de _MAX_ registros)",
-    "sInfoPostFix": "",
-    "sInfoThousands": ".",
-    "sLengthMenu": "_MENU_ resultados por página",
-    "sLoadingRecords": "Carregando...",
-    "sProcessing": "Processando...",
-    "sZeroRecords": "Nenhum registro encontrado",
-    "sSearch": "Pesquisar",
-    "oPaginate": {
-      "sNext": "Próximo",
-      "sPrevious": "Anterior",
-      "sFirst": "Primeiro",
-      "sLast": "Último"
-    },
-    "oAria": {
-      "sSortAscending": ": Ordenar colunas de forma ascendente",
-      "sSortDescending": ": Ordenar colunas de forma descendente"
-    }
-  };
-
   if ($('#visitors-list').length) {
-    //enable datatable list
     var visitorTable = $('#visitors-list').DataTable({
-      language: dataTableLang
+      language: {
+        url: datatableLocaleUrl
+      }
     });
   }
 


### PR DESCRIPTION
Translate the list based on user settings using datatables own translation files.

closes #223

- [x] No backslash to call class, ie. AVOID "new \DOMXPath" (I recommend to run grep "new \" on files commited)
- [x] Don't put the branch name in the title of the PR neither issue number.
- [x] Updates on commits only concerns the target issue. None other updates should be pushed  
- [x] Each methods does one single task. AVOID multiple tasks on same method. 
- [x] Logs follow actions and are consistent with rest of platform
- [x] All previous comments on existing code have been considered
- [x] Always leave the last comma in a multi-line array (Zend Coding Style)
- [x] I've explained on Issue's comment how did I test it on Integration environment (local tested are irrelevant).
- [x] ... and the most important, I've ran my code