### PR TITLE
ENHANCEMENT: Saves the OneSignal notification_id in Item

### DIFF
--- a/sitebuilder/app/models/Items.php
+++ b/sitebuilder/app/models/Items.php
@@ -46,7 +46,7 @@ class Items extends \lithium\data\Model {
 		'title' => array('type' => 'string', 'null' => false),
 		'thumbnails' => array('type' => 'array', 'default' => []),
 		'groups' => array('type' => 'array', 'default' => []),
-		'notification_id'=>array('type'=>'string', 'default' => ''),
+		'notification_id' => array('type' => 'string', 'default' => ''),
 	);
 
 	protected $privateFields = ['groups'];

--- a/sitebuilder/app/models/Items.php
+++ b/sitebuilder/app/models/Items.php
@@ -45,7 +45,8 @@ class Items extends \lithium\data\Model {
 		'type' => array('type' => 'string', 'null' => false),
 		'title' => array('type' => 'string', 'null' => false),
 		'thumbnails' => array('type' => 'array', 'default' => []),
-		'groups' => array('type' => 'array', 'default' => [])
+		'groups' => array('type' => 'array', 'default' => []),
+		'notification_id'=>array('type'=>'string', 'default' => ''),
 	);
 
 	protected $privateFields = ['groups'];

--- a/sitebuilder/lib/meumobi/sitebuilder/services/SendOneSignalNotification.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/SendOneSignalNotification.php
@@ -31,9 +31,9 @@ class SendOneSignalNotification
 		Logger::debug(self::COMPONENT, 'payload request', $notification);
 
 		try {
-			$api->notifications->add($notification);
+			$response = $api->notifications->add($notification);
 			
-			return true;
+			return [ 'notification_id' => $response['id'] ];
 		} catch (OneSignalException $e) {
 			Logger::error(self::COMPONENT, 'push notification not sent', [
 				'app' => $app,

--- a/sitebuilder/lib/meumobi/sitebuilder/services/SendOneSignalNotification.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/SendOneSignalNotification.php
@@ -32,7 +32,7 @@ class SendOneSignalNotification
 
 		try {
 			$api->notifications->add($notification);
-
+			
 			return true;
 		} catch (OneSignalException $e) {
 			Logger::error(self::COMPONENT, 'push notification not sent', [
@@ -66,7 +66,7 @@ class SendOneSignalNotification
 		}
 
 		if ($banner) {
-			$notification['large_picture'] = $banner;
+			$notification['big_picture'] = $banner;
 		}
 
 		if ($icon) {

--- a/sitebuilder/lib/meumobi/sitebuilder/services/SendPushNotification.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/SendPushNotification.php
@@ -76,7 +76,7 @@ class SendPushNotification
 		$notification_response = $service->perform($app, $notif);
 
 		if ($notification_response !== false) {
-			if ($site->pushnotif_service=='onesignal' && isset($notification_response['notification_id'])){
+			if ($site->pushnotif_service == 'onesignal' && isset($notification_response['notification_id'])) {
 				$item->notification_id = $notification_response['notification_id'];
 				$item->save();
 			}

--- a/sitebuilder/lib/meumobi/sitebuilder/services/SendPushNotification.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/SendPushNotification.php
@@ -73,7 +73,13 @@ class SendPushNotification
 			'parameters' => $notif,
 		]);
 
-		if ($service->perform($app, $notif)) {
+		$notification_response = $service->perform($app, $notif);
+
+		if ($notification_response !== false) {
+			if ($site->pushnotif_service=='onesignal' && isset($notification_response['notification_id'])){
+				$item->notification_id = $notification_response['notification_id'];
+				$item->save();
+			}
 			Logger::info(self::COMPONENT, 'push notification sent', $log);
 		}
 	}


### PR DESCRIPTION
ENHANCEMENT, Closes #441 Saves the OneSignal notification_id in Item when the Push Notification is sent.

PS: I've tested this functionality using `$devices = ['<player-id>'];` instead of `$devices = $this->getDevicesTokens($item, $site);` on line 22 in the SendPushNotification.php file. Just to test the OneSignal api request with some data and have a valid response to handle.