### PR TITLE
FIX: GenericMediaHandler improved to match audio/mpeg <=>mp3

### DIFF
--- a/config/settings.php
+++ b/config/settings.php
@@ -7,6 +7,9 @@ Config::write('Security.salt', 'a5d5d5be3c69dbc8b49e3342db0f8952f6328abd67076bf6
 Config::write('Mailer.transport', 'mail');
 
 Config::write('Sites.blacklist', array());
+Config::write('FileExtensions.blacklist', array(
+	'mpga', 'mp2', 'mp2a'
+));
 
 Config::write('PushWoosh.authToken', 'z8slYDk24hm2SJDIhzi6SBcdFPjCMU870gEH4wJ9WbzcdJsC6RBVl72r7k12b99yoHxZ39VDoOPYNsoLLtRk');
 Config::write('OneSignal.authToken', 'Yjk0ZGM0NjctOWE3MC00YTZkLWE2Y2UtMDdhYTVlODczZGE3');

--- a/sitebuilder/lib/meumobi/sitebuilder/services/ProcessRemoteMedia/GenericMediaHandler.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/ProcessRemoteMedia/GenericMediaHandler.php
@@ -104,7 +104,7 @@ class GenericMediaHandler
 			return $actualExt;
 		}
 
-		if (!empty($allowedExtensions[0])){
+		if (!empty($allowedExtensions[0])) {
 			return $allowedExtensions[0];			
 		}
 


### PR DESCRIPTION
FIX: Closes #450, GenericMediaHandler improved to match audio/mpeg <=> mp3

What was done: 

- Created a blacklist of file extensions in [config/settings.php](https://github.com/danielindiano/sitebuilder/blob/1d8eec5fe50a7d7b59a21c85c907f703ea391bd0/config/settings.php#L10-L12) to prevent the MediaHandler matches these extensions.

- Create a function in [GenericMediaHandler](https://github.com/danielindiano/sitebuilder/blob/1d8eec5fe50a7d7b59a21c85c907f703ea391bd0/sitebuilder/lib/meumobi/sitebuilder/services/ProcessRemoteMedia/GenericMediaHandler.php#L93-L113) that gets the actual extension of remote file, and checks if it is in the allowed extensions for the content type. So it returns the most suitable extension;
