### PR TITLE
FEATURE: Export devices to onesignal

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/entities/Device.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/entities/Device.php
@@ -10,6 +10,7 @@ class Device extends Entity
 	protected $userId;
 	protected $siteId;
 	protected $pushId;
+	protected $playerId;
 	protected $model;
 	protected $manufacturer;
 	protected $platform;
@@ -49,6 +50,11 @@ class Device extends Entity
 		return $this->pushId;
 	}
 
+	public function playerId()
+	{
+		return $this->playerId;
+	}
+	
 	public function appVersion()
 	{
 		return $this->appVersion;

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/DevicesRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/DevicesRepository.php
@@ -48,6 +48,20 @@ class DevicesRepository extends Repository
 		}
 	}
 
+	public function findForExport($site_id, $user_ids = null)
+	{
+		$criteria = [
+			'site_id' => (int) $site_id,
+			'player_id' => ['$eq' => null],
+		];
+
+		if ($user_ids) {
+			$criteria['user_id'] = ['$in' => $user_ids];
+		}
+
+		return $this->hydrateSet($this->collection()->find($criteria));
+	}
+
 	public function findForPushNotif($site_id, $user_ids)
 	{
 		$criteria = [
@@ -115,6 +129,7 @@ class DevicesRepository extends Repository
 			'user_id' => $object->userId(),
 			'site_id' => (int) $object->siteId(),
 			'push_id' => $object->pushId(),
+			'player_id' => $object->playerId(),
 			'model' => $object->model(),
 			'manufacturer' => $object->manufacturer(),
 			'platform' => $object->platform(),

--- a/sitebuilder/lib/meumobi/sitebuilder/repositories/DevicesRepository.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/repositories/DevicesRepository.php
@@ -52,7 +52,7 @@ class DevicesRepository extends Repository
 	{
 		$criteria = [
 			'site_id' => (int) $site_id,
-			'player_id' => ['$eq' => null],
+			'player_id' => ['$in' => ['', null]],
 		];
 
 		if ($user_ids) {

--- a/sitebuilder/lib/meumobi/sitebuilder/services/CreateOrUpdateDevice.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/CreateOrUpdateDevice.php
@@ -27,6 +27,9 @@ class CreateOrUpdateDevice
 
 		if ($device) {
 			Logger::debug(self::COMPONENT, 'device found. updating', $log);
+			if ($device->pushId() != $data['push_id']){
+				$data['player_id'] = null;
+			}
 			$device->update($data);
 
 			$repository->update($device);

--- a/sitebuilder/lib/meumobi/sitebuilder/services/ProcessRemoteMedia/YoutubeHandler.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/ProcessRemoteMedia/YoutubeHandler.php
@@ -17,6 +17,9 @@ class YoutubeHandler
 	public function perform($url)
 	{
 		$id = $this->getVideoId($url);
+		Logger::debug(self::COMPONENT, 'Extract video id from url', [
+		      'id' => $id
+		    ]);
 		$youtube = new Youtube(['key' => 'AIzaSyDkAG5Oge5ZOyyVSJKpHpyFY6GsSaE3WIc']);
 
 		$info = $youtube->getVideoInfo($id);
@@ -41,8 +44,8 @@ class YoutubeHandler
 		];
 	}
 
-	protected function getVideoId($url) {
-		if (preg_match('/youtube.com\/watch\?v=(\w+)/', $url, $matches)) {
+	protected function getVideoId($url) {	
+		if (preg_match("/^(?:http(?:s)?:\/\/)?(?:www\.)?(?:m\.)?(?:youtu\.be\/|youtube\.com\/(?:(?:watch)?\?(?:.*&)?v(?:i)?=|(?:embed|v|vi|user)\/))([^\?&\"'>]+)/", $url, $matches)) {
 			return $matches[1];
 		}
 	}

--- a/sitebuilder/script/export_devices_to_onesignal.php
+++ b/sitebuilder/script/export_devices_to_onesignal.php
@@ -1,0 +1,60 @@
+<?php
+
+use meumobi\sitebuilder\Logger;
+use meumobi\sitebuilder\entities\Device;
+use meumobi\sitebuilder\repositories\DevicesRepository;
+use OneSignal\OneSignal;
+use OneSignal\Devices;
+use OneSignal\Config as OneSignalConfig;
+use OneSignal\Exception\OneSignalException;
+
+require dirname(__DIR__) . '/config/cli.php';
+
+
+$options = getopt('s:');
+
+$siteId = $options['s'];
+$site = Model::load('Sites')->firstById($siteId);
+$repo = new DevicesRepository();
+
+if (!$site->pushnotif_app_id || $site->pushnotif_service != 'onesignal') {
+	return false;
+}
+
+$appId = $site->pushnotif_app_id;
+$appAuthToken = $site->pushnotif_app_auth_token;
+
+$config = new OneSignalConfig();
+$config->setApplicationId($appId);
+$config->setApplicationAuthKey($appAuthToken);
+$config->setUserAuthKey(Config::read('OneSignal.authToken'));
+
+$api = new OneSignal($config);
+
+$devices = $repo->findForExport($siteId);
+
+foreach ($devices as $device) {
+	$deviceData = [
+		'identifier' => $device->pushId(),		
+		'device_model' => $device->model(),
+		'device_os' => $device->platformVersion(),
+		'game_version' => $device->appVersion(),
+	];
+	if($device->playerId()){ 
+		$response = $api->devices->update($device->playerId(), $deviceData);
+		//TODO: include the log entry
+	}
+	else{
+		$deviceData['device_type'] = 
+			(strtolower($device->platform()) == 'android') ? 
+			Devices::ANDROID: 
+			Devices::IOS;
+		$response = $api->devices->add($deviceData);
+		//TODO: include the log entry
+		$device->update([
+					'player_id' => $response['id']
+				]);
+		$repo->update($device);
+		
+	}
+}

--- a/sitebuilder/script/export_devices_to_onesignal.php
+++ b/sitebuilder/script/export_devices_to_onesignal.php
@@ -10,51 +10,57 @@ use OneSignal\Exception\OneSignalException;
 
 require dirname(__DIR__) . '/config/cli.php';
 
+class ExportDevicesToOneSignal {
 
+	const COMPONENT = 'export_devices_onesignal';
+
+	public function perform($siteId) {
+		$site = Model::load('Sites')->firstById($siteId);
+		$repo = new DevicesRepository();
+		if (!$site->pushnotif_app_id || $site->pushnotif_service != 'onesignal') {
+			return false;
+		}
+
+		$appId = $site->pushnotif_app_id;
+		$appAuthToken = $site->pushnotif_app_auth_token;
+
+		$config = new OneSignalConfig();
+		$config->setApplicationId($appId);
+		$config->setApplicationAuthKey($appAuthToken);
+		$config->setUserAuthKey(Config::read('OneSignal.authToken'));
+
+		$api = new OneSignal($config);
+
+		$devices = $repo->findForExport($siteId);
+
+		foreach ($devices as $device) {
+			$deviceData = [
+				'identifier' => $device->pushId(),		
+				'device_model' => $device->model(),
+				'device_os' => $device->platformVersion(),
+				'game_version' => $device->appVersion(),
+			];
+			if ($device->playerId()) {
+				Logger::info(self::COMPONENT, 'playerId already exists: Updating the device data');
+				$response = $api->devices->update($device->playerId(), $deviceData);
+			}
+			else {
+				Logger::info(self::COMPONENT, 'playerId did not exists: Adding the device');
+				$deviceData['device_type'] =
+					(strtolower($device->platform()) == 'android') ? 
+					Devices::ANDROID:
+					Devices::IOS;
+				$response = $api->devices->add($deviceData);
+				$device->update([
+							'player_id' => $response['id']
+						]);
+				$repo->update($device);
+			}
+		}
+	}
+}
+
+//TODO Analyze if this script should become a worker
 $options = getopt('s:');
-
 $siteId = $options['s'];
-$site = Model::load('Sites')->firstById($siteId);
-$repo = new DevicesRepository();
-
-if (!$site->pushnotif_app_id || $site->pushnotif_service != 'onesignal') {
-	return false;
-}
-
-$appId = $site->pushnotif_app_id;
-$appAuthToken = $site->pushnotif_app_auth_token;
-
-$config = new OneSignalConfig();
-$config->setApplicationId($appId);
-$config->setApplicationAuthKey($appAuthToken);
-$config->setUserAuthKey(Config::read('OneSignal.authToken'));
-
-$api = new OneSignal($config);
-
-$devices = $repo->findForExport($siteId);
-
-foreach ($devices as $device) {
-	$deviceData = [
-		'identifier' => $device->pushId(),		
-		'device_model' => $device->model(),
-		'device_os' => $device->platformVersion(),
-		'game_version' => $device->appVersion(),
-	];
-	if($device->playerId()){ 
-		$response = $api->devices->update($device->playerId(), $deviceData);
-		//TODO: include the log entry
-	}
-	else{
-		$deviceData['device_type'] = 
-			(strtolower($device->platform()) == 'android') ? 
-			Devices::ANDROID: 
-			Devices::IOS;
-		$response = $api->devices->add($deviceData);
-		//TODO: include the log entry
-		$device->update([
-					'player_id' => $response['id']
-				]);
-		$repo->update($device);
-		
-	}
-}
+(new ExportDevicesToOneSignal())->perform($siteId);


### PR DESCRIPTION
Closes #429, Created script to import devices to OneSignal service.

Running from the project root:
` php sitebuilder/script/export_devices_to_onesignal.php -s<siteId>`

Where <siteId> must be replaced by the Id of the site.