### PR TITLE
FIX: Extraction of medias from rss feeds improved;

### DIFF
--- a/sitebuilder/lib/meumobi/sitebuilder/services/UpdateNewsFeed.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/UpdateNewsFeed.php
@@ -20,6 +20,7 @@ use app\models\Items;
 use app\models\items\Articles;
 use meumobi\sitebuilder\Logger;
 use meumobi\sitebuilder\validators\ParamsValidator;
+use meumobi\sitebuilder\services\ProcessRemoteMedia\GenericMediaHandler;
 
 class UpdateNewsFeed
 {
@@ -357,9 +358,12 @@ class UpdateNewsFeed
 	protected function extractImages($article, $xpath)
 	{
 		$filter = function($enclosure) {
+			$mediaHandler = new GenericMediaHandler;
+			list($info, $httpStatus) = $mediaHandler->perform($enclosure->get_link());
+			list($type) = explode('/', $info['type']);
 			return $enclosure->get_link() && (
-				!$enclosure->get_medium() ||
 				$enclosure->get_medium() == 'image'
+				&& $type == 'image'
 			);
 		};
 


### PR DESCRIPTION
FIX: Closes #383, Extraction of medias from rss feeds improved;

In order to avoid the download of large files incorrectly, and ensure that the media files extracted are in the correct mime type. I Used the GenericMediaHandler service to check the files during extraction;