### PR TITLE
FIX: Visitor's default password now is based in a inflection of site's title

### DIFF
--- a/sitebuilder/app/views/visitors/_form.htm.php
+++ b/sitebuilder/app/views/visitors/_form.htm.php
@@ -46,7 +46,7 @@
 		<div class="form-grid-460 first">
 			<?= $this->form->input('default_password', [
 				'type' => 'checkbox',
-				'label' => s('Use default password: "%s"', $site->slug),
+				'label' => s('Use default password: "%s"', Inflector::slug($site->title, '')),
 				'value' => 1
 			]) ?>
 		</div>

--- a/sitebuilder/lib/core/common/Inflector.php
+++ b/sitebuilder/lib/core/common/Inflector.php
@@ -28,7 +28,7 @@ class Inflector {
             '/ß/' => 'ss',
             '/[^\w\s]/' => ' ',
             '/\\s+/' => $replace,
-            '/^' . $replace . '+|' . $replace . '+$/' => ''
+            '/^[' . $replace . ']+|[' . $replace . ']+$/' => ''
         );
         
         return strtolower(preg_replace(array_keys($map), array_values($map), $string));

--- a/sitebuilder/lib/meumobi/sitebuilder/services/VisitorPasswordGenerationService.php
+++ b/sitebuilder/lib/meumobi/sitebuilder/services/VisitorPasswordGenerationService.php
@@ -4,6 +4,7 @@ namespace meumobi\sitebuilder\services;
 
 use Exception;
 use Security;
+use Inflector;
 
 class VisitorPasswordGenerationService
 {
@@ -33,6 +34,6 @@ class VisitorPasswordGenerationService
 
 	protected function defaultPassword($site)
 	{
-		return $site->slug;
+		return Inflector::slug($site->title, '');
 	}
 }


### PR DESCRIPTION
FIX: Closes #330, Visitor's default password now is based in a inflection of site's title;

For it gets clear, the change in the Inflector class was made to enable  the function slug to accept a empty string in `$replace` parameter. So I added brackets to avoid the regular expression crash.